### PR TITLE
added celery

### DIFF
--- a/celery_conf.py
+++ b/celery_conf.py
@@ -1,0 +1,6 @@
+# Celery config.
+# Broker (message queue) url.
+BROKER_URL = 'amqp://guest:guest@localhost:5672//'
+
+# Result backend.
+CELERY_RESULT_BACKEND = 'redis://localhost:6379/0'

--- a/install_celery
+++ b/install_celery
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ "$OSTYPE" =~ ^darwin ]]
+then
+    brew install rabbitmq
+    brew install redis
+
+# Otherwise, assume Linux...
+else
+    sudo apt-get install rabbitmq-server -y
+    sudo apt-get install redis-server -y
+fi
+
+pip install celery redis

--- a/run_celery
+++ b/run_celery
@@ -1,0 +1,31 @@
+#!/bin/bash
+trap : SIGTERM SIGINT
+
+# If using a virtualenv, set its path here
+VENV=~/env/celery
+
+# Module where the celery object is
+MODULE=lib.Worker.Models.uv_task
+
+# Run everything in the background,
+# but remember their process IDs.
+
+redis-server &
+REDIS_PID=$!
+
+rabbitmq-server &
+
+source $VENV/bin/activate
+celery multi start 2 -A $MODULE
+WORKR_PID=$!
+
+wait
+
+if [[ $? -gt 128 ]]
+then
+    echo "Shutting down..."
+    kill $REDIS_PID
+    kill $WORKR_PID
+    ps auxww | grep 'celery worker' | awk '{print $2}' | xargs kill
+    rabbitmqctl stop
+fi


### PR DESCRIPTION
I added in the basic stuff for celery support, haven't been able to test it yet though b/c I'm not sure how to trigger the tasks, but it _should_ work.

you can run `install_celery` to get all the dependencies setup. then you can run `run_celery` to start the rabbitmq and redis servers, and the celery workers. if you're using a virtualenv you'll need to modify the `VENV` variable, if not, you should just remove the `source $VENV...` line.

let me know if you have any questions!
